### PR TITLE
Fixed verified commits workflow

### DIFF
--- a/.github/workflows/check-verified-commits.yml
+++ b/.github/workflows/check-verified-commits.yml
@@ -15,15 +15,17 @@ jobs:
           fetch-depth: 0 # Fetch full history
 
       - name: Check Verified Commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          UNVERIFIED_COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%h %G?" | grep -v "G$" || true)
+          UNVERIFIED_COMMITS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[] | select(.commit.verification.verified == false) | .sha')
           
           if [[ -n "$UNVERIFIED_COMMITS" ]]; then
-            echo "❌ Unverified commits detected:"
-            echo "Please try and verify your commits"
+            echo ":x: Unverified commits detected in this Pull Request:"
             echo "$UNVERIFIED_COMMITS"
+            echo "Please ensure all commits are signed and verified."
             exit 1
           else
-            echo "✅ All commits are verified."
-            echo "We will get back to you as fast as possible ✨"
+            echo ":white_check_mark: All commits in this PR are verified."
+            echo "We will get back to you as fast as possible :sparkles:"
           fi

--- a/.github/workflows/check-verified-commits.yml
+++ b/.github/workflows/check-verified-commits.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          UNVERIFIED_COMMITS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[] | select(.commit.verification.verified == false) | .sha')
+          UNVERIFIED_COMMITS=$(gh api --paginate repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[] | select(.commit.verification.verified == false) | .sha')
           
           if [[ -n "$UNVERIFIED_COMMITS" ]]; then
             echo "❌ Unverified commits detected in this Pull Request:"

--- a/.github/workflows/check-verified-commits.yml
+++ b/.github/workflows/check-verified-commits.yml
@@ -16,16 +16,16 @@ jobs:
 
       - name: Check Verified Commits
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           UNVERIFIED_COMMITS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[] | select(.commit.verification.verified == false) | .sha')
           
           if [[ -n "$UNVERIFIED_COMMITS" ]]; then
-            echo ":x: Unverified commits detected in this Pull Request:"
+            echo "❌ Unverified commits detected in this Pull Request:"
             echo "$UNVERIFIED_COMMITS"
             echo "Please ensure all commits are signed and verified."
             exit 1
           else
-            echo ":white_check_mark: All commits in this PR are verified."
-            echo "We will get back to you as fast as possible :sparkles:"
+            echo "✅ All commits in this PR are verified."
+            echo "We will get back to you as fast as possible ✨"
           fi


### PR DESCRIPTION
I updated .github/workflows/check-verified-commits.yml to use the GitHub API to check for verification. The old way (using git log) was failing because the CI machine didn't have the public key to verify that the signature was yours. By using the API, the CI now asks GitHub directly: "Is this commit verified by you?"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request verification workflow with clearer messaging that refers specifically to "this Pull Request" and instructs verifying all commits.
  * Enhanced verification to more accurately detect and report unverified commits for the current PR, and updated success messaging when all commits are verified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->